### PR TITLE
Menu improvements

### DIFF
--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -58,7 +58,9 @@ MainWindow::MainWindow(WordSearchDoc *wsdoc, QWidget *parent)
 void MainWindow::SetupWindow()
 {
     setWindowFilePath(QString("Untitled"));
+#ifndef Q_OS_MAC
     setWindowTitle("Untitled[*] - Word Search Creator");
+#endif
     QScrollArea *scrollArea = new QScrollArea;
     scrollArea->setWidget(wsdraw);
 

--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -28,8 +28,6 @@
 #include <QDesktopServices>
 #include <QCloseEvent>
 
-#include <QDebug>
-
 #include "wordsearchdrawer.h"
 #include "wordsearchdoc.h"
 #include "wordsearchcontrol.h"
@@ -382,8 +380,7 @@ void MainWindow::SetupWindow()
 bool MainWindow::event(QEvent *event)
 {
     if (event->type() == QEvent::WindowActivate || event->type() == QEvent::WindowDeactivate)
-    {
-        qDebug() << "Window " <<this->windowTitle() << " activated";
+    {;
         WordSearchApplication *app = static_cast<WordSearchApplication*>(QApplication::instance());
         app->setWindowCheck();
         if (event->type() == QEvent::WindowDeactivate)
@@ -450,7 +447,6 @@ void MainWindow::changeWordSpace(QAction *action)
 
 void MainWindow::updateWindowMenu()
 {
-    qDebug() << "updateWindowMenu()";
     WordSearchApplication *app = static_cast<WordSearchApplication*>(QApplication::instance());
     foreach (QAction *action, windowActions)
     {
@@ -484,7 +480,6 @@ void MainWindow::updateWindowMenu()
 
 void MainWindow::setWindowCheck()
 {
-    qDebug() << "MainWindow::setWindowCheck()";
     WordSearchApplication *app = static_cast<WordSearchApplication*>(QApplication::instance());
     int i=0;
     foreach (MainWindow *window, app->windows)
@@ -520,7 +515,6 @@ void MainWindow::windowSelected(QAction *action)
     }
     else
     {
-        qDebug() << "Raising Window";
         selctedWindow->raise();
         selctedWindow->activateWindow();
     }

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -49,6 +49,8 @@ private:
     QList<QAction*> windowActions;
     QActionGroup *windowselectorGroup;
     QAction *thisWindowAction; //The action that represents this window.
+    QList<QAction*> actionsDisableOnMinimise;
+    bool event(QEvent *event);
 
 private slots:
     void ShowDoc();
@@ -58,6 +60,7 @@ private slots:
     void changelistorder(QAction *listorderaction);
     void changeWordSpace(QAction *action);
     void updateWindowMenu();
+    void setWindowCheck();
     void windowSelected(QAction *action);
     void maximise();
     void minimise();

--- a/updatechecker.cpp
+++ b/updatechecker.cpp
@@ -40,7 +40,7 @@ UpdateChecker::UpdateChecker(QObject *parent) :
 void UpdateChecker::checkForUpdate(bool manual = false)
 {
     QUrlQuery query;
-    QUrl url("http://www.wordsearchcreator.org/update/1.2/check.php");
+    QUrl url("http://www.wordsearchcreator.org/update/1.1/check.php");
     if (manual)
         query.addQueryItem("type", "manual");
     else

--- a/wordsearchapplication.cpp
+++ b/wordsearchapplication.cpp
@@ -25,8 +25,6 @@
 #include <QFontDatabase>
 #endif
 
-#include <QDebug>
-
 #include "wordsearchdoc.h"
 #include "mainwindow.h"
 #include "updatechecker.h"
@@ -153,7 +151,6 @@ void WordSearchApplication::quitApplication()
 #ifdef Q_OS_MAC
 void WordSearchApplication::updateDockMenu()
 {
-    qDebug() << "updateDockMenu()";
     foreach (QAction *action, windowActions)
     {
         dockMenu->removeAction(action);
@@ -184,7 +181,6 @@ void WordSearchApplication::updateDockMenu()
 void WordSearchApplication::setWindowCheck()
 {
 #ifdef Q_OS_MAC
-    qDebug() << "setWindowCheck()";
     int i=0;
     foreach (MainWindow *window, windows)
     {
@@ -201,7 +197,6 @@ void WordSearchApplication::windowSelected(QAction *action)
 {
     //One of the windows was selected off the dock menu
     QMainWindow *selctedWindow = windows.at(action->data().toInt());
-    qDebug() << "window Selected " << action->data().toInt() << " " << selctedWindow->windowTitle() << "State: " << selctedWindow->windowState();
     if (selctedWindow->windowState().testFlag(Qt::WindowState::WindowMinimized))
     {
         //Seems the only way to restore a minimised window on macOS is to use showMaximized() or showNormal() but we must know which to use.
@@ -216,7 +211,6 @@ void WordSearchApplication::windowSelected(QAction *action)
     }
     else
     {
-        qDebug() << "Raising Window";
         selctedWindow->raise();
         selctedWindow->activateWindow();
     }

--- a/wordsearchapplication.cpp
+++ b/wordsearchapplication.cpp
@@ -43,6 +43,7 @@ WordSearchApplication::WordSearchApplication( int & argc, char **argv ) :
     Splash->show();
     processEvents();
 
+#ifdef Q_OS_MAC
     dockMenu = new QMenu("DockMenu");
     dockMenu->setAsDockMenu();
     dockSerprator = dockMenu->addSeparator();
@@ -51,6 +52,7 @@ WordSearchApplication::WordSearchApplication( int & argc, char **argv ) :
     connect(newAct, SIGNAL(triggered()), this, SLOT(New()));
     windowselectorGroup = new QActionGroup(this);
     connect(windowselectorGroup, SIGNAL(triggered(QAction*)), this, SLOT(windowSelected(QAction*)));
+#endif
 
     int fileloaded = false;
     WordSearchDoc *newwsd;
@@ -131,10 +133,13 @@ void WordSearchApplication::deRegisterWindow(MainWindow *window)
 
 void WordSearchApplication::updateWindowLists()
 {
-    //Emitting this signal will cause all MainWindows to update
-    //their window menus and the dock menu to be updated.
+    //Emitting this signal will cause all MainWindows to update their window menus
     emit windowListChanged();
+
+#ifdef Q_OS_MAC
+    //On macOS we also want and the dock menu to be updated
     updateDockMenu();
+#endif
 }
 
 void WordSearchApplication::quitApplication()
@@ -145,6 +150,7 @@ void WordSearchApplication::quitApplication()
     }
 }
 
+#ifdef Q_OS_MAC
 void WordSearchApplication::updateDockMenu()
 {
     qDebug() << "updateDockMenu()";
@@ -173,9 +179,11 @@ void WordSearchApplication::updateDockMenu()
         i++;
     }
 }
+#endif
 
 void WordSearchApplication::setWindowCheck()
 {
+#ifdef Q_OS_MAC
     qDebug() << "setWindowCheck()";
     int i=0;
     foreach (MainWindow *window, windows)
@@ -183,6 +191,9 @@ void WordSearchApplication::setWindowCheck()
         windowActions[i]->setChecked(window->isActiveWindow());
         i++;
     }
+#endif
+    //Emitting this signal will cause all MainWindows to update their window menu
+    //check mark ensuuing it is against the currently focused window
     emit currentWindowChanged();
 }
 

--- a/wordsearchapplication.h
+++ b/wordsearchapplication.h
@@ -25,6 +25,9 @@
 class MainWindow;
 class UpdateChecker;
 class QSplashScreen;
+class QMenu;
+class QAction;
+class QActionGroup;
 
 class WordSearchApplication : public QApplication
 {
@@ -36,18 +39,29 @@ public:
     void deRegisterWindow(MainWindow *window);
     QList<MainWindow*> windows;
     UpdateChecker *updateChecker;
+    QMenu *dockMenu;
+    void setWindowCheck();
 
 private:
     MainWindow *window;
     void loadFile(const QString &fileName);
     QSplashScreen *Splash ;
+    QList<QAction*> windowActions;
+    QActionGroup *windowselectorGroup;
+    QAction *dockSerprator;
+    void updateDockMenu();
 
 signals:
     void windowListChanged();
+    void currentWindowChanged();
 
 public slots:
     void quitApplication();
-    void updateWindowLists();
+    void updateWindowLists();    
+    void New();
+
+private slots:
+    void windowSelected(QAction *action);
 };
 
 #endif // WORDSEARCHAPPLICATION_H

--- a/wordsearchapplication.h
+++ b/wordsearchapplication.h
@@ -39,17 +39,21 @@ public:
     void deRegisterWindow(MainWindow *window);
     QList<MainWindow*> windows;
     UpdateChecker *updateChecker;
+#ifdef Q_OS_MAC
     QMenu *dockMenu;
+#endif
     void setWindowCheck();
 
 private:
     MainWindow *window;
     void loadFile(const QString &fileName);
     QSplashScreen *Splash ;
+#ifdef Q_OS_MAC
     QList<QAction*> windowActions;
     QActionGroup *windowselectorGroup;
     QAction *dockSerprator;
     void updateDockMenu();
+#endif
 
 signals:
     void windowListChanged();

--- a/wordsearchcontrol.cpp
+++ b/wordsearchcontrol.cpp
@@ -148,7 +148,9 @@ int WordSearchControl::Save()
     this->parentWidget()->parentWidget()->setWindowFilePath(wsd->filename);
     WordSearchApplication *app = static_cast<WordSearchApplication*>(QApplication::instance());
     app->updateWindowLists();
+#ifndef Q_OS_MAC
     this->parentWidget()->parentWidget ()->setWindowTitle(wsd->filename + "[*] - Word Search Creator");
+#endif
     wsd->saveToIO(file);
     wsd->setEditedState(false);
     file.close();
@@ -206,7 +208,9 @@ void WordSearchControl::SetupTemplate()
     this->parentWidget()->parentWidget()->setWindowFilePath(QString("Untitled"));
     WordSearchApplication *app = static_cast<WordSearchApplication*>(QApplication::instance());
     app->updateWindowLists();
+#ifndef Q_OS_MAC
     this->parentWidget()->parentWidget ()->setWindowTitle("Untitled[*] - Word Search Creator");
+#endif
     wsd->setEditedState(false);
 }
 
@@ -284,7 +288,9 @@ void WordSearchControl::UpdateConts()
     this->parentWidget()->parentWidget()->setWindowFilePath(wsd->filename);
     WordSearchApplication *app = static_cast<WordSearchApplication*>(QApplication::instance());
     app->updateWindowLists();
+#ifndef Q_OS_MAC
     this->parentWidget()->parentWidget()->setWindowTitle(wsd->filename + "[*] - Word Search Creator");
+#endif
     useMaskChanged(wsd->getUseMask());
 }
 

--- a/wordsearchcontrol.cpp
+++ b/wordsearchcontrol.cpp
@@ -49,7 +49,6 @@ WordSearchControl::WordSearchControl(QWidget *)
     connect(yspin, SIGNAL(valueChanged(int)), this, SIGNAL(YValChanged(int)));
     connect(createbutton, SIGNAL(clicked()), this, SLOT(createclicked()));
     connect(WordListBox, SIGNAL(textChanged()), this, SLOT(updateNoLines()));
-    //connect(http, SIGNAL(requestFinished(int, bool)), this, SLOT(httpRequestFinished(int, bool)));
 }
 
 void WordSearchControl::createclicked()


### PR DESCRIPTION
Changes to menu behaviour on macOS, especially around window switching, to make it behave more like a native macOS application.
Minimising and restoring windows now works as expected.
Includes addition of dock menu and moving the check for updates action to the application menu.